### PR TITLE
Fixed loading for plugin managers like vim-plug

### DIFF
--- a/lua/onebuddy.lua
+++ b/lua/onebuddy.lua
@@ -4,7 +4,6 @@
 -- Maintainer:   Th3Whit3Wolf <the.white.wolf.is.1337@gmail.com>
 -- Website:      httpc.//github.com/Th3Whit3Wolf/onebuddy
 -- License:      MIT
-vim.cmd('packadd colorbuddy.nvim')
 local Color, c, Group, g, s = require("colorbuddy").setup()
 local b = s.bold
 local i = s.italic


### PR DESCRIPTION
removed vim.cmd('packadd colorbuddy.nvim')
This statement prevents loading of this plugin in plugin manager like vim-plug.
**Note:** Didn't check with pathogen