### PR TITLE
Color of floating windows fixed

### DIFF
--- a/lua/onebuddy.lua
+++ b/lua/onebuddy.lua
@@ -591,7 +591,7 @@ Group.new('NERDTreeFile', c.mono_1, c.none, no)
 
 -- Coc.nvim Floating Background fix
 Group.new('CocFloating', c.mono_1, c.none, no)
-Group.new('NormalFloat', c.mono_1, c.none, no)
+Group.new('NormalFloat', c.mono_1, c.pmenu, no)
 -----------------------------
 --     LSP Highlighting    --
 -----------------------------


### PR DESCRIPTION
Replaced the background of the NormalFloat option from "none" to "pmenu" to fix the lack of this color in the floating windows in the editor

## Unchanged
![autocompe](https://user-images.githubusercontent.com/65829671/113231077-0ac30200-9260-11eb-9f98-670e9e14cc66.png)

![delete](https://user-images.githubusercontent.com/65829671/113231092-1282a680-9260-11eb-8868-d5e37154dd92.png)

##With changes
![completecorre](https://user-images.githubusercontent.com/65829671/113231161-3ba33700-9260-11eb-8782-f5cc39ceae7c.png)

![correct1](https://user-images.githubusercontent.com/65829671/113231175-43fb7200-9260-11eb-8541-b153bfb4998c.png)
